### PR TITLE
Moved to Flink 1.4.0

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -16,7 +16,7 @@ scalaVersion in ThisBuild := "2.11.11"
 
 parallelExecution in Test := false
 
-val flinkVersion = "1.3.2"
+val flinkVersion = "1.4.0"
 val dep_flink = Seq(
   "org.apache.flink" %% "flink-scala" % flinkVersion % "provided",
   "org.apache.flink" %% "flink-streaming-scala" % flinkVersion % "provided",

--- a/src/main/scala/org/codefeedr/Core/Library/Internal/Kafka/Source/KafkaTableSource.scala
+++ b/src/main/scala/org/codefeedr/Core/Library/Internal/Kafka/Source/KafkaTableSource.scala
@@ -23,6 +23,7 @@ import org.apache.flink.api.common.typeinfo.TypeInformation
 import org.apache.flink.streaming.api.datastream.DataStream
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment
 import org.apache.flink.streaming.api.functions.source.SourceFunction
+import org.apache.flink.table.api.TableSchema
 import org.apache.flink.table.sources.StreamTableSource
 import org.apache.flink.types.Row
 import org.codefeedr.Core.Library.{SubjectFactory, TypeInformationServices}
@@ -42,4 +43,8 @@ class KafkaTableSource(subjectType: SubjectType) extends StreamTableSource[Row] 
     */
   override def getReturnType: TypeInformation[Row] =
     TypeInformationServices.GetEnrichedRowTypeInfo(subjectType)
+
+  override def getTableSchema: TableSchema = {
+    TableSchema.fromTypeInfo(getReturnType)
+  }
 }

--- a/src/main/scala/org/codefeedr/Core/Library/Internal/Zookeeper/ZkClient.scala
+++ b/src/main/scala/org/codefeedr/Core/Library/Internal/Zookeeper/ZkClient.scala
@@ -23,13 +23,19 @@ import java.util
 
 import scala.collection.JavaConverters._
 import com.typesafe.config.{Config, ConfigFactory}
-import org.apache.zookeeper.AsyncCallback._
-import org.apache.zookeeper.KeeperException.Code
-import org.apache.zookeeper.Watcher.Event
-import org.apache.zookeeper.Watcher.Event._
-import org.apache.zookeeper.ZooDefs.Ids.OPEN_ACL_UNSAFE
-import org.apache.zookeeper._
-import org.apache.zookeeper.data.Stat
+import org.apache.flink.shaded.zookeeper.org.apache.zookeeper.AsyncCallback._
+import org.apache.flink.shaded.zookeeper.org.apache.zookeeper.KeeperException.Code
+import org.apache.flink.shaded.zookeeper.org.apache.zookeeper.Watcher.Event
+import org.apache.flink.shaded.zookeeper.org.apache.zookeeper.Watcher.Event.KeeperState
+import org.apache.flink.shaded.zookeeper.org.apache.zookeeper.data.Stat
+import org.apache.flink.shaded.zookeeper.org.apache.zookeeper.ZooDefs.Ids.OPEN_ACL_UNSAFE
+import org.apache.flink.shaded.zookeeper.org.apache.zookeeper.{
+  CreateMode,
+  KeeperException,
+  WatchedEvent,
+  Watcher,
+  ZooKeeper
+}
 import org.codefeedr.Core.Library.Internal.Serialisation.{GenericDeserialiser, GenericSerialiser}
 
 import scala.concurrent.ExecutionContext.Implicits.global

--- a/src/main/scala/org/codefeedr/Core/Library/Internal/Zookeeper/ZkException.scala
+++ b/src/main/scala/org/codefeedr/Core/Library/Internal/Zookeeper/ZkException.scala
@@ -19,8 +19,8 @@
 
 package org.codefeedr.Core.Library.Internal.Zookeeper
 
-import org.apache.zookeeper.KeeperException
-import org.apache.zookeeper.data.Stat
+import org.apache.flink.shaded.zookeeper.org.apache.zookeeper.KeeperException
+import org.apache.flink.shaded.zookeeper.org.apache.zookeeper.data.Stat
 
 case class ZkClientException(exception: KeeperException,
                              path: Option[String],

--- a/src/main/scala/org/codefeedr/Core/Library/SubjectLibrary.scala
+++ b/src/main/scala/org/codefeedr/Core/Library/SubjectLibrary.scala
@@ -20,7 +20,7 @@
 package org.codefeedr.Core.Library
 
 import com.typesafe.scalalogging.LazyLogging
-import org.apache.zookeeper.KeeperException.NodeExistsException
+import org.apache.flink.shaded.zookeeper.org.apache.zookeeper.KeeperException.NodeExistsException
 import org.codefeedr.Core.Library.Internal.Serialisation.GenericSerialiser
 import org.codefeedr.Core.Library.Internal.SubjectTypeFactory
 import org.codefeedr.Core.Library.Internal.Zookeeper.{ZkClient, ZkNode}


### PR DESCRIPTION
After moving to Flink 1.4.0 I had to update:
- Zookeeper imports (they have a different package in 1.4)
- Implement `getTableSchema` method in KafkaTableSource class

@nvankaam can you check if I did the getTableSchema implementation correctly?